### PR TITLE
fix: setup semantic release and build caching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,6 @@ jobs:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         id: semantic_release
-        # if: github.event_name != 'pull_request'
         with:
           dry_run: true
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,9 +7,50 @@ on:
     branches:
       - main
 jobs:
+  prepare:
+    name: Build EKS AMI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    env:
+      SYSBOX_VERSION: 0.6.2
+    outputs:
+      new_release_version: ${{ steps.semantic_release.outputs.new_release_version }}
+      sysbox_version: ${{ env.SYSBOX_VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PLURAL_BOT_PAT }}
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
+        if: github.event_name != 'pull_request'
+        with:
+          node-version: 18.12.1
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v3
+        id: semantic_release
+        if: github.event_name != 'pull_request'
+        with:
+          dry_run: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.PLURAL_BOT_PAT }}
+          NODE_AUTH_TOKEN: ${{ secrets.PLURAL_BOT_NPM_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Get files
+        run: make get-files
+      - name: Cache downloaded files
+        uses: actions/cache/save@v3
+        with:
+          path: tmp
+          key: ${{ runner.os }}-build-${{ env.SYSBOX_VERSION }}
   packer_build_eks:
     name: Build EKS AMI
     runs-on: ubuntu-latest
+    needs: prepare
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -18,25 +59,27 @@ jobs:
         k8s_version: ["1.23", "1.24", "1.25", "1.26"]
         ubuntu_version: ["focal-20.04"]
         architecture: ["amd64", "arm64"]
+        sysbox_version: ["${{ needs.prepare.outputs.sysbox_version }}"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
-        if: github.event_name != 'pull_request'
+        if: always() && (github.event_name != 'pull_request')
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::654897662046:role/github-actions/plural-sysbox-amis-packer
           role-session-name: SysboxAmisPacker
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Get files
-        run: make get-files
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
         id: setup
         with:
           version: 1.9.2
+      - name: Restore downloaded files
+        uses: actions/cache/restore@v3
+        with:
+          path: tmp
+          key: ${{ runner.os }}-build-${{ matrix.sysbox_version }}
       - name: Run `packer init`
         id: init
         run: "packer init ."
@@ -45,12 +88,39 @@ jobs:
         run: "packer validate ."
       - name: Run `packer build`
         id: build
-        if: github.event_name != 'pull_request'
+        if: always() && (github.event_name != 'pull_request')
         env:
           PKR_VAR_k8s_version: ${{ matrix.k8s_version }}
           PKR_VAR_ubuntu_version: ${{ matrix.ubuntu_version }}
           PKR_VAR_architecture: ${{ matrix.architecture }}
+          PKR_VAR_sysbox_version: ${{ matrix.sysbox_version }}
+          PKR_VAR_img_version: ${{ needs.prepare.outputs.new_release_version }}
         run: "packer build ."
+  release:
+    runs-on: ubuntu-latest
+    needs: packer_build_eks
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PLURAL_BOT_PAT }}
+      - name: 'Setup Node'
+        uses: actions/setup-node@v3
+        if: github.event_name != 'pull_request'
+        with:
+          node-version: 18.12.1
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v3
+        id: semantic_release
+        if: github.event_name != 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PLURAL_BOT_PAT }}
+          NODE_AUTH_TOKEN: ${{ secrets.PLURAL_BOT_NPM_TOKEN }}
   # trivy-scan:
   #   name: Trivy fs scan
   #   runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,15 +38,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PLURAL_BOT_PAT }}
           NODE_AUTH_TOKEN: ${{ secrets.PLURAL_BOT_NPM_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Get files
-        run: make get-files
-      - name: Cache downloaded files
-        uses: actions/cache/save@v3
+      - name: Cache sysbox and cri-o files
+        id: sysbox_cache
+        uses: actions/cache@v3
         with:
           path: tmp
           key: ${{ runner.os }}-build-${{ env.SYSBOX_VERSION }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        if: steps.sysbox_cache.outputs.cache-hit != 'true'
+      - name: Get sysbox and cri-o files
+        if: steps.sysbox_cache.outputs.cache-hit != 'true'
+        run: make get-files
   packer_build_eks:
     name: Build EKS AMI
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
       SYSBOX_VERSION: 0.6.2
     outputs:
       new_release_version: ${{ steps.semantic_release.outputs.new_release_version }}
+      new_release_published: ${{ steps.semantic_release.outputs.new_release_published }}
       sysbox_version: ${{ env.SYSBOX_VERSION }}
     steps:
       - name: Checkout
@@ -32,7 +33,7 @@ jobs:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         id: semantic_release
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         with:
           dry_run: true
         env:
@@ -88,7 +89,7 @@ jobs:
         run: "packer validate ."
       - name: Run `packer build`
         id: build
-        if: always() && (github.event_name != 'pull_request')
+        if: always() && (github.event_name != 'pull_request' && needs.prepare.outputs.new_release_published == 'true')
         env:
           PKR_VAR_k8s_version: ${{ matrix.k8s_version }}
           PKR_VAR_ubuntu_version: ${{ matrix.ubuntu_version }}

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,0 +1,18 @@
+name: "Semantic PR"
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SYSBOX_VERSION=v0.6.2
+SYSBOX_VERSION ?= 0.6.2
 
 get-files:
 	rm -rf ./tmp
@@ -6,8 +6,8 @@ get-files:
 	mkdir -p ./tmp/sysbox/arm64/bin
 	mkdir -p ./tmp/crio/amd64
 	mkdir -p ./tmp/crio/arm64
-	docker run --rm --platform linux/amd64 -v ./tmp:/host registry.nestybox.com/nestybox/sysbox-deploy-k8s:${SYSBOX_VERSION} /bin/bash -c "cp /opt/sysbox/bin/generic/* /host/sysbox/amd64/bin/ && cp -r /opt/sysbox/systemd/ /host/sysbox/systemd/ && cp -r /opt/crio-deploy/bin/* /host/crio/amd64/ && cp -r /opt/crio-deploy/config/ /host/crio/config/ && cp -r /opt/crio-deploy/scripts/ /host/crio/scripts/"
-	docker run --rm --platform linux/arm64 -v ./tmp:/host registry.nestybox.com/nestybox/sysbox-deploy-k8s:${SYSBOX_VERSION} /bin/bash -c "cp /opt/sysbox/bin/generic/* /host/sysbox/arm64/bin/ && cp -r /opt/crio-deploy/bin/* /host/crio/arm64/"
+	docker run --rm --platform linux/amd64 -v ./tmp:/host registry.nestybox.com/nestybox/sysbox-deploy-k8s:v${SYSBOX_VERSION} /bin/bash -c "cp /opt/sysbox/bin/generic/* /host/sysbox/amd64/bin/ && cp -r /opt/sysbox/systemd/ /host/sysbox/systemd/ && cp -r /opt/crio-deploy/bin/* /host/crio/amd64/ && cp -r /opt/crio-deploy/config/ /host/crio/config/ && cp -r /opt/crio-deploy/scripts/ /host/crio/scripts/"
+	docker run --rm --platform linux/arm64 -v ./tmp:/host registry.nestybox.com/nestybox/sysbox-deploy-k8s:v${SYSBOX_VERSION} /bin/bash -c "cp /opt/sysbox/bin/generic/* /host/sysbox/arm64/bin/ && cp -r /opt/crio-deploy/bin/* /host/crio/arm64/"
 
 packer-init:
 	packer init .


### PR DESCRIPTION
With semantic release we should be able to set our "internal" version for the image build automatically. Also sets up a separate job to download the files from the sysbox container image so this doesn't need to be duplicated many times. It also (hopefully) resolves an issue with packer not being able to exit gracefully and clean itself up if one of the builds fails.